### PR TITLE
Opam: Correct homepage URI

### DIFF
--- a/opam
+++ b/opam
@@ -3,8 +3,8 @@ license: "ISC"
 maintainer: "Joel Jakubovic"
 authors: "Joel Jakubovic"
 dev-repo: "https://github.com/jdjakub/ansi-parse.git"
-homepage: "https://github.com/jdjakub/ansiparse"
-bug-reports: "https://github.com/jdjakub/ansiparse/issues"
+homepage: "https://github.com/jdjakub/ansi-parse"
+bug-reports: "https://github.com/jdjakub/ansi-parse/issues"
 build: [ "ocaml" "pkg/pkg.ml" "build"
   "--pinned" pinned ]
 depends: [


### PR DESCRIPTION
This PR updates the OPAM package metadata for `homepage` and `bug-reports`: the dash in the middle of the project name was missing.

(I found this error clicking on a link in the [MirageOS documentation repository](http://docs.mirage.io/).)

Have a nice day!